### PR TITLE
My First Python Project

### DIFF
--- a/Correctspellings-checkpoint.ipynb
+++ b/Correctspellings-checkpoint.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The SpellChecker module in Python is one of the handiest tools that can be used to correct misspelt words in a piece of text. If you have never used this Python module before, you can easily install it in your Python virtual environment by running the command mentioned below in your command prompt or terminal:

pip install pyspellchecker